### PR TITLE
Include Netplan.io

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -84,6 +84,7 @@ microsoft-authentication-library-for-python
 multipath-tools
 neofetch
 net-tools
+netplan.io
 netcat-openbsd
 nfs-common
 nftablesdracut-network


### PR DESCRIPTION
* https://packages.debian.org/trixie/netplan.io
* required for openstack bare metal
