### PR TITLE
Add xargs with the max-procs

### DIFF
--- a/download_pkgs
+++ b/download_pkgs
@@ -47,7 +47,8 @@ xargs apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts -
 join -v 1 <(cat arch_import_list recursive_depends | sort | uniq) pkgs | { grep -v -x -f "$exclude_patterns" || true; } > recursive_needed
 
 mkdir apt_download
-(cd apt_download && xargs apt-get download) < recursive_needed
+# Download the packages via apt-get download in parallel with n threads.
+(cd apt_download && xargs -n 1 -P $(nproc --all) apt-get download ) < recursive_needed
 
 find apt_download -name "*.deb" | while read -r pkg; do
 	hash="$(sha256sum < "$pkg" | head -c 64)"


### PR DESCRIPTION
In this PR, we extend the ability to fetch a release not sequentially, but with some degree of parallelism. The code will create `n` threats, based on the number of CPUs available on the build node. 