### PR TITLE
add azure-nvme-utils

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -6,6 +6,7 @@ apparmor
 arptables
 auditd
 awscli
+azure-nvme-utils
 binutils
 bird2
 bsdextrautils


### PR DESCRIPTION
required for persistent volumes on Kubernetes 

see for reference: 
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/bc01df44486ffaa21790bbbcf87bedcd13a9f7c4/pkg/azuredisk/azure_common_linux.go#L111
