### PR TITLE
Add sshguard package

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ flowchart TD
 ## GitHub
 
 - `gardenlinux/repo`
-	- collect packages from `package-*` repos, fetch all dependecies from debian snapshot and publish into an APT repo distribution
+	- collect packages from `package-*` repos, fetch all dependencies from debian snapshot and publish into an APT repo distribution
 - [`gardenlinux/repo-debian-snapshot`](https://github.com/gardenlinux/repo-debian-snapshot)
 	- regularly snapshot debian testing (needed for reproducible package and repo builds)
 - [`gardenlinux/package-build`](https://github.com/gardenlinux/package-build)

--- a/package-imports
+++ b/package-imports
@@ -136,10 +136,11 @@ selinux-basics
 selinux-policy-default
 sg3-utils
 sgml-base
-smartmontools
 slirp4netns
+smartmontools
 socat
 sosreport
+sshguard
 sssd
 strace
 sudo


### PR DESCRIPTION
We chose to replace fail2ban with sshguard.
Thus, sshguard needs to be added to our repo.

Related to https://github.com/gardenlinux/gardenlinux/issues/2221
