### PR TITLE
Update import from python 3.11 to 3.12

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -117,7 +117,7 @@ python3-pip
 python3-pip-whl
 python3-setuptools-whl
 python3-systemd
-python3.11
+python3.12
 qemu-block-extra
 qemu-efi-aarch64
 qemu-guest-agent


### PR DESCRIPTION
Our python 3.11 package is not building anymore, so we need to upgrade to a supported version.