### PR TITLE
Retry failed repo builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,3 +129,13 @@ jobs:
             build /create_dist /repo today 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           aws s3 cp --recursive 'repo/dists/today' 's3://${{ vars.S3_BUCKET }}/gardenlinux/dists/today'
           aws cloudfront create-invalidation --distribution-id '${{ secrets.CLOUDFRONT_DISTRIBUTION }}' --paths '/gardenlinux/dists/today/*'
+  # Attempt to make CI more resilient using retry logic https://github.com/gardenlinux/gardenlinux/issues/2288
+  re-run:
+    needs: [ build ]
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run rerun-build.yml -F run_id=${{ github.run_id }}

--- a/.github/workflows/rerun-build.yml
+++ b/.github/workflows/rerun-build.yml
@@ -1,0 +1,17 @@
+name: re-run build
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
We had failed repo builds quite often recently which causes manual effort.
Let's try to mitigate this using retry logic.

Taken from https://github.com/gardenlinux/repo-debian-snapshot/tree/main/.github/workflows

Related to https://github.com/gardenlinux/gardenlinux/issues/2288
