### PR TITLE
packages for dogfooding GL in platform-test-images

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -22,7 +22,6 @@ cloud-guest-utils
 cloud-init
 conntrack
 containerd
-containerd
 containernetworking-plugins
 cryptsetup
 curl
@@ -31,7 +30,6 @@ dkms
 dnsmasq
 dnsutils
 docker.io
-docker.io
 dosfstools
 dracut
 dracut-live
@@ -39,9 +37,9 @@ dracut-network
 dwarves
 ebtables
 efibootmgr
-efitools
-efi-shell-x64
 efi-shell-aa64
+efi-shell-x64
+efitools
 ethtool
 fatresize
 flex
@@ -83,9 +81,9 @@ mdadm
 mstflint
 multipath-tools
 neofetch
-net-tools
-netplan.io
 netcat-openbsd
+netplan.io
+net-tools
 nfs-common
 nftables
 nodejs
@@ -94,18 +92,19 @@ nullmailer
 numactl
 nvme-cli
 open-iscsi
-open-vm-tools
 openssh-server
 openssl
+open-vm-tools
 openvswitch-switch
 ostree
 ovmf
 patchelf
 pciutils
-podman
 pkexec
+podman
 polkitd
 pristine-lfs
+python3.12
 python3-apt
 python3-cffi-backend
 python3-click
@@ -117,7 +116,6 @@ python3-pip
 python3-pip-whl
 python3-setuptools-whl
 python3-systemd
-python3.12
 qemu-block-extra
 qemu-efi-aarch64
 qemu-guest-agent
@@ -128,7 +126,6 @@ quota
 rng-tools5
 rootlesskit
 rsync
-rsyslog-relp
 rsyslog-relp
 runc
 sbsigntool

--- a/package-imports
+++ b/package-imports
@@ -3,6 +3,7 @@ aide
 aide-common
 amazon-ec2-utils
 apparmor
+apt-transport-https
 arptables
 auditd
 awscli
@@ -50,8 +51,10 @@ git
 gnupg
 google-compute-engine-oslogin
 google-guest-agent
+guestfish
 haveged
 hdparm
+inetutils-ping
 ipmitool
 iptables
 iputils-arping
@@ -133,6 +136,7 @@ selinux-basics
 selinux-policy-default
 sg3-utils
 sgml-base
+shellcheck
 slirp4netns
 smartmontools
 socat
@@ -150,6 +154,7 @@ tcpd
 tcpdump
 tpm2-tools
 traceroute
+unzip
 usbutils
 usr-is-merged
 vim


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds packages for dogfooding GL in platform-test-images.

See also https://github.com/gardenlinux/gardenlinux/pull/2339

**Special notes for reviewers**:
Merge after https://github.com/gardenlinux/repo/pull/22
