### PR TITLE
remove guestfish

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -51,7 +51,6 @@ git
 gnupg
 google-compute-engine-oslogin
 google-guest-agent
-guestfish
 haveged
 hdparm
 inetutils-ping


### PR DESCRIPTION
**What this PR does / why we need it**:

`guestfish` is now built without db-utils in
https://github.com/gardenlinux/package-linux

