### PR TITLE
Add passt package, needed for running rootless podman

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -101,6 +101,7 @@ open-vm-tools
 openvswitch-switch
 ostree
 ovmf
+passt
 patchelf
 pciutils
 pkexec


### PR DESCRIPTION
This package is needed for running podman in rootless mode https://packages.debian.org/trixie/passt

While that's not a core feature of Garden Linux I still think it would be nice to have Garden Linux be able to be the container host Linux environment for non-Gardener use-cases.