### PR TITLE
build source index

### DIFF
--- a/create_dist
+++ b/create_dist
@@ -23,6 +23,19 @@ for arch in all amd64 arm64; do
 	echo " $hash $size main/binary-$arch/Packages.gz" >> "$index_files"
 done
 
+dir="$target/dists/$dist/main/source"
+mkdir -p "$dir"
+(cd "$target" && dpkg-scansources pool) > "$dir/Sources"
+
+size="$(wc -c "$dir/Sources" | awk '{ print $1 }')"
+hash="$(sha256sum "$dir/Sources" | head -c 64)"
+echo " $hash $size main/source/Sources" >> "$index_files"
+gzip < "$dir/Sources" > "$dir/Sources.gz"
+rm "$dir/Sources"
+size="$(wc -c "$dir/Sources.gz" | awk '{ print $1 }')"
+hash="$(sha256sum "$dir/Sources.gz" | head -c 64)"
+echo " $hash $size main/source/Sources.gz" >> "$index_files"
+
 date="$(date -R -u)"
 
 cat << EOF | gpg --clearsign > "$target/dists/$dist/InRelease"

--- a/download_pkgs
+++ b/download_pkgs
@@ -33,6 +33,15 @@ find download -name "*_all.deb" -or -name "*_$arch.deb" | sort | while read -r p
 	cp --update=none "$pkg" "$target/pool/$hash/"
 done
 
+find download -name "*.dsc" | sort | while read -r src; do
+	hash="$(sha256sum < "$src" | head -c 64)"
+	mkdir -p "$target/pool/$hash"
+	cp --update=none "$src" "$target/pool/$hash/$(basename "$src")"
+	awk '/^Files:$/ { flag = 1; next } !/^ / { flag = 0; } flag { print $3 }' < "$src" | while read f; do
+		cp --update=none "download/$f" "$target/pool/$hash/$f"
+	done
+done
+
 rm -rf download
 sort -o pkgs -u pkgs
 
@@ -48,12 +57,22 @@ join -v 1 <(cat arch_import_list recursive_depends | sort | uniq) pkgs | { grep 
 
 mkdir apt_download
 (cd apt_download && xargs apt-get download) < recursive_needed
+(cd apt_download && xargs apt-get source --download-only) < recursive_needed
 
 find apt_download -name "*.deb" | while read -r pkg; do
 	hash="$(sha256sum < "$pkg" | head -c 64)"
 	mkdir -p "$target/pool/$hash"
 	cp --update=none "$pkg" "$target/pool/$hash/"
 	rm "$pkg"
+done
+
+find apt_download -name "*.dsc" | while read -r src; do
+	hash="$(sha256sum < "$src" | head -c 64)"
+	mkdir -p "$target/pool/$hash"
+	cp --update=none "$src" "$target/pool/$hash/$(basename "$src")"
+	awk '/^Files:$/ { flag = 1; next } !/^ / { flag = 0; } flag { print $3 }' < "$src" | while read f; do
+		cp --update=none "apt_download/$f" "$target/pool/$hash/$f"
+	done
 done
 
 rm -rf apt_download


### PR DESCRIPTION
include source packages into the package pool and create corresponding source index

Fixes https://github.com/gardenlinux/gardenlinux/issues/2384