### PR TITLE
remove python from package-imports

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -107,7 +107,6 @@ pkexec
 podman
 polkitd
 pristine-lfs
-python3.13
 python3-apt
 python3-cffi-backend
 python3-click


### PR DESCRIPTION
We don't want to use debian's binary package, but rather our own rebuild
