### PR TITLE
Add docker-cli to package-imports

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -31,6 +31,7 @@ dkms
 dnsmasq
 dnsutils
 docker.io
+docker-cli
 dosfstools
 dracut
 dracut-live


### PR DESCRIPTION
**What this PR does / why we need it**:
The _docker.io_ package provides for some time only the daemon. As docker is still used in certain contexts by the ironcore colleagues, we'd like to have _docker-cli_ also added to the repo.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: