### PR TITLE
Trim packages

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -11,7 +11,6 @@ azure-vm-utils
 binutils
 bsdextrautils
 btrfs-progs
-bubblewrap
 build-essential
 ca-certificates
 ceph

--- a/package-imports
+++ b/package-imports
@@ -9,7 +9,6 @@ auditd
 awscli
 azure-vm-utils
 binutils
-bird2
 bsdextrautils
 btrfs-progs
 bubblewrap

--- a/package-imports
+++ b/package-imports
@@ -104,7 +104,6 @@ pciutils
 pkexec
 podman
 polkitd
-pristine-lfs
 python3-apt
 python3-cffi-backend
 python3-click


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduce friction during release.

This is a refined version of the PR #15 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

* bird2 only used by ironcore, it was removed in favour of frr https://github.com/gardenlinux/gardenlinux/commit/88220841f110dac127e60a9e9ef32ba1f01a382b
* bubblewrap only used by ostree poc, we can remove dependency now https://gitlab.com/gardenlinux/gardenlinux-package-build/-/commit/c6a24462d6dba7490884c97fcbd235d114d14692
* pristine-lfs was used by old package-build in gitlab, we now store everything in OCI, S3 or GitHub artifacts - nothing in git LFS via pristine-lfs tool.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
