### PR TITLE
Fix package-exclude

### DIFF
--- a/download_pkgs
+++ b/download_pkgs
@@ -66,6 +66,9 @@ awk '{ print $1; print $1 ":amd64"; print $1 ":arm64" }' < recursive_depends > r
 xargs apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances < recursive_depends_extended | grep '^\w' | sort | uniq > recursive_depends_real
 
 sed 's/$/:.*/' < "$exclude_patterns" > exclude_extended
+# native packages do not have :arch postfix, so we need both
+cat  "$exclude_patterns" >> exclude_extended
+
 comm -23 recursive_depends_real pkgs | { grep -v -x -f exclude_extended || true; } > recursive_needed
 
 mkdir apt_download


### PR DESCRIPTION

**What this PR does / why we need it**:
native packages do not have :arch postfix, this PR adds the native name to the exclude_extended list

**Which issue(s) this PR fixes**:
exclude packages for both architectures 
