### PR TITLE
fix exclude package for native packages

### DIFF
--- a/download_pkgs
+++ b/download_pkgs
@@ -65,10 +65,7 @@ xargs apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts -
 awk '{ print $1; print $1 ":amd64"; print $1 ":arm64" }' < recursive_depends > recursive_depends_extended
 xargs apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances < recursive_depends_extended | grep '^\w' | sort | uniq > recursive_depends_real
 
-# Exclude pkg:arm64, pkg:amd64, pkg:any
-sed 's/$/:.*/' < "$exclude_patterns" > exclude_extended
-# Exclude pkg (no :arch suffix)
-awk '{ print $1 }' < "$exclude_patterns" >> exclude_extended
+sed 'p;s/$/:.*/' < "$exclude_patterns" > exclude_extended
 comm -23 recursive_depends_real pkgs | { grep -v -x -f exclude_extended || true; } > recursive_needed
 
 mkdir apt_download

--- a/download_pkgs
+++ b/download_pkgs
@@ -65,7 +65,10 @@ xargs apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts -
 awk '{ print $1; print $1 ":amd64"; print $1 ":arm64" }' < recursive_depends > recursive_depends_extended
 xargs apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances < recursive_depends_extended | grep '^\w' | sort | uniq > recursive_depends_real
 
+# Exclude pkg:arm64, pkg:amd64, pkg:any
 sed 's/$/:.*/' < "$exclude_patterns" > exclude_extended
+# Exclude pkg (no :arch suffix)
+awk '{ print $1 }' < "$exclude_patterns" >> exclude_extended
 comm -23 recursive_depends_real pkgs | { grep -v -x -f exclude_extended || true; } > recursive_needed
 
 mkdir apt_download


### PR DESCRIPTION
**What this PR does / why we need it**:
binary packages can be native to your host system (e.g. apt-utils),
 or can indicate foreign arch (e.g. apt-utils:arch).

The package exclusion did not consider packages without a :arch suffix


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/2882
