### PR TITLE
exclude db5.3-utils

### DIFF
--- a/package-exclude
+++ b/package-exclude
@@ -1,4 +1,5 @@
 apt-utils
 db-util
+db5.3-util
 libdb-dev
 libdb5\.3.*


### PR DESCRIPTION
db5.3-util is not installed in images, and will break during installation since dependency `libdb5.3` is already wiped. 

This PR just cleans up this dead package. 