### PR TITLE
Add sshfs package, used by lima-vm

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -138,6 +138,7 @@ slirp4netns
 smartmontools
 socat
 sosreport
+sshfs
 sshguard
 sssd
 strace


### PR DESCRIPTION
Related to https://github.com/gardenlinux/gardenlinux/issues/2964

Lima-vm uses sshfs to shared folder support, the requirement is documented here:
https://lima-vm.io/docs/faq/#can-i-run-non-ubuntu-guests
