### PR TITLE
import python3-netifaces

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -109,6 +109,7 @@ python3-apt
 python3-cffi-backend
 python3-click
 python3-debian
+python3-netifaces
 python3-networkx
 python3-novaclient
 python3-pefile


### PR DESCRIPTION
explicitly import python3-netifaces, required for vmware feature
