### PR TITLE
Add nfs-kernel-server Issue:#3142

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -86,6 +86,7 @@ net-tools
 netcat-openbsd
 netplan.io
 nfs-common
+nfs-kernel-server
 nftables
 nodejs
 npm


### PR DESCRIPTION
**What this PR does / why we need it**:
Add nfs-kernel-server for Portworx for ECS on Container Services task
[https://docs.portworx.com/portworx-enterprise/platform/kubernetes/bare-metal/bare-metal/operations/storage-operations/create-pvcs/open-nfs-ports](url)

**Which issue(s) this PR fixes**:
Fixes # [https://github.com/gardenlinux/gardenlinux/issues/3142](3142)

**Special notes for your reviewer**:
As discussed in the channel, its better to put in package-imports for nightly compatibility

