### PR TITLE
add gdb, debuginfod and its dependencies

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -31,6 +31,7 @@ dnsutils
 docker-cli
 docker.io
 dosfstools
+debuginfod
 dracut
 dracut-live
 dracut-network
@@ -45,6 +46,7 @@ execline
 fatresize
 flex
 gcc
+gdb
 gdisk
 gettext
 git
@@ -64,8 +66,15 @@ kernel-wedge
 kexec-tools
 keyutils
 libengine-pkcs11-openssl
+libbabeltrace1
+libdebuginfod-common
+libdebuginfod1t64
+libdw1t64
 libpam-passwdqc
 libpam-pwquality
+libpython3.13
+libsource-highlight-common
+libsource-highlight4t64
 libvirt-clients
 libvirt-daemon-system
 libxi6


### PR DESCRIPTION
**What this PR does / why we need it**:
 - Add package imports for gdb, debuginfod from Debian repo which is already closest versions in upstream

**Which issue(s) this PR fixes**:
 - Fixes [#3268](https://github.com/gardenlinux/gardenlinux/issues/3268)
