### PR TITLE
Add the python-is-python3 package

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -113,6 +113,7 @@ pciutils
 pkexec
 podman
 polkitd
+python-is-python3
 python3-apt
 python3-cffi-backend
 python3-click
@@ -169,7 +170,6 @@ usbutils
 usr-is-merged
 vim
 waagent
-what-is-python
 wget
 xfsprogs
 yq


### PR DESCRIPTION
**What this PR does / why we need it**:

In our installation we do not have the `python-is-python3` package. This should be added to our repo. 

**Which issue(s) this PR fixes**:
Fixes [#3313](https://github.com/gardenlinux/gardenlinux/issues/3313)
