### PR TITLE
Feature/gnutls bin

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -54,6 +54,7 @@ gdisk
 gettext
 git
 gnupg
+gnutls-bin
 google-compute-engine-oslogin
 google-guest-agent
 haveged


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to check if our GnuTLS-related libraries are in FIPS mode. For this we need the gnutls binaries.

Relates: https://github.com/gardenlinux/gardenlinux/issues/3436
