### PR TITLE
Remove gnutls, since we build a FIPS enabled version now.

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -54,7 +54,6 @@ gdisk
 gettext
 git
 gnupg
-gnutls-bin
 google-compute-engine-oslogin
 google-guest-agent
 haveged


### PR DESCRIPTION
Since we're building [GnuTLS](https://github.com/gardenlinux/package-gnutls) with FIPS now, we do not need to import gnutls anylonger. 