### PR TITLE
Add package:stress-ng for features/checkbox

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -170,6 +170,7 @@ sshfs
 sshguard
 sssd
 strace
+stress-ng
 sudo
 swtpm
 syslinux


### PR DESCRIPTION
**What this PR does / why we need it**:
Add package: `stress-ng` required for CPU HW checks for `features/checkbox`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/internal-docs/issues/113
