### PR TITLE
push the repo build 30 mins earlier

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '30 23 * * *'
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:
the nightly broke today (18.Jun) as the repo was not ready, proposal to move the build 30 mins earlier

**Which issue(s) this PR fixes**:
Fixes [4955](https://github.com/gardenlinux/gardenlinux/issues/4955)