### PR TITLE
docs: remove "AI-generated phrasing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To find our more, visit our
 ## Licensing
 
 Copyright 2025 SAP SE or an SAP affiliate company and GardenLinux contributors.
-Please see our [LICENSE](LICENSE.md) for copyright and license information.
+See our [LICENSE](LICENSE.md) for copyright and license information.
 Detailed information including third-party components and their
 licensing/copyright information is available
 [via the REUSE tool](https://reuse.software).

--- a/docs/explanation/repo-infrastructure.md
+++ b/docs/explanation/repo-infrastructure.md
@@ -24,7 +24,7 @@ github_target_path: docs/explanation/repo-infrastructure.md
 
 # Repository Infrastructure
 
-This document provides a deep dive into the technical infrastructure that powers the Garden Linux repository system, including AWS setup, release processes and maintenance procedures.
+This document provides a describes the technical infrastructure that powers the Garden Linux repository system, including AWS setup, release processes and maintenance procedures.
 
 ```mermaid
 flowchart TD

--- a/docs/explanation/repo-infrastructure.md
+++ b/docs/explanation/repo-infrastructure.md
@@ -75,7 +75,7 @@ The repo-debian-snapshot system was designed to address several requirements:
 - **Long-Term Validity**: Snapshot repository metadata is signed with a 100-year validity period, preventing expiration issues that would break older builds. In contrast, the official Debian snapshot service uses keys with much shorter validity periods, which can cause builds to fail when accessing older snapshots
 - **Performance**: Lightweight metadata-only snapshots are faster to create and require less storage than archiving full package files
 - **Control**: Garden Linux can create snapshots at precisely the times needed for releases rather than relying on external snapshot schedules
-- **AWS Integration**: Tight integration with AWS infrastructure enables seamless signing, storage, and distribution
+- **AWS Integration**: Tight integration with AWS infrastructure enables automatic signing, storage, and distribution
 - **Focused Scope**: Snapshots contain only what Garden Linux needs (testing, specific architectures) rather than the entire Debian archive history
 
 ### What repo-debian-snapshot Does
@@ -108,7 +108,7 @@ Debian snapshots serve two critical roles:
 
 ## AWS Infrastructure
 
-Garden Linux leverages AWS services to host and distribute its package repositories:
+Garden Linux uses AWS services to host and distribute its package repositories:
 
 ### S3 Bucket Structure
 

--- a/docs/how-to/apt-repos.md
+++ b/docs/how-to/apt-repos.md
@@ -1,6 +1,6 @@
 ---
 title: Creating APT Repository Releases
-description: Comprehensive guide to creating releases for Garden Linux APT repositories
+description: Complete guide to creating releases for Garden Linux APT repositories
 order: 2
 related_topics:
   - /explanation/release-hierarchy.md
@@ -34,7 +34,7 @@ This document is about the second tier, the [Repository Infrastructure](/explana
 
 ## Understanding APT Repository Releases
 
-Please read the [APT Repository Infrastructure](/explanation/repo-infrastructure.md) to get familiar with the concepts for the Releases.
+Read the [APT Repository Infrastructure](/explanation/repo-infrastructure.md) to get familiar with the concepts for the Releases.
 
 ## Prerequisites
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes "AI-generated phrasing". Definitions what qualifies at such phrasing [as documented](https://github.com/gardenlinux/docs-ng/blob/ae2f8301aa7673444fea3b7b794603fc951e9c31/docs/contributing/documentation/writing_good_docs.md#ai-generated-phrasing-to-avoid).
The removal of the phrases was done via the [documentation-humanize workflow](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/workflows/documentation-humanize.md) and [skill](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/skills/documentation-humanize/SKILL.md).