### PR TITLE
Add/postgresql common

### DIFF
--- a/package-imports
+++ b/package-imports
@@ -126,6 +126,7 @@ pciutils
 pkexec
 podman
 polkitd
+postgresql-common
 python-is-python3
 python3-apt
 python3-cffi-backend


### PR DESCRIPTION
For a container, we need the postgresql-common for the client. 