### PR TITLE
feat: remove migration frontmatter as migration is done

### DIFF
--- a/docs/explanation/repo-infrastructure.md
+++ b/docs/explanation/repo-infrastructure.md
@@ -12,10 +12,6 @@ related_topics:
   - /how-to/releases/apt-repos.md
   - /how-to/releases/os-releases.md
   - /reference/releases/release-lifecycle
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4633"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: repo
 github_source_path: docs/explanation/repo-infrastructure.md

--- a/docs/how-to/apt-repos.md
+++ b/docs/how-to/apt-repos.md
@@ -12,10 +12,6 @@ related_topics:
   - /how-to/releases/apt-repos.md
   - /how-to/releases/os-releases.md
   - /reference/releases/release-lifecycle
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: repo
 github_source_path: docs/how-to/releases/apt-repos.md


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/gardenlinux/gardenlinux/issues/4332 we used migration markers in the frontmatter to track the migration status. These can now be removed as the documentation system is live.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5048
