### PR TITLE
Exit if package-releases contain duplicates

### DIFF
--- a/download_pkgs
+++ b/download_pkgs
@@ -11,6 +11,9 @@ dir="$(mktemp -d)"
 trap 'cd / && rm -rf "$dir"' EXIT
 cd "$dir"
 
+# extra check in case manual changes to the package-releases added duplicates
+awk '{ print $1 }' "$releases" | sort | uniq -d | grep . && echo "Error: duplicate package in package-releases, exiting!" >&2 && exit 1
+
 mkdir download
 while read -r repo tag; do
 	gh release download --dir download --repo "$repo" "$tag"


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual changes to package-releases might introduce duplicates that were missed, repo build should not proceed if that is the case.

**Which issue(s) this PR fixes**:
Fixes #
