### PR TITLE
Fix github_source_path in apt-repos.md

### DIFF
--- a/docs/how-to/apt-repos.md
+++ b/docs/how-to/apt-repos.md
@@ -14,7 +14,7 @@ related_topics:
   - /reference/releases/release-lifecycle
 github_org: gardenlinux
 github_repo: repo
-github_source_path: docs/how-to/releases/apt-repos.md
+github_source_path: docs/how-to/apt-repos.md
 github_target_path: docs/how-to/releases/apt-repos.md
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix github_source_path in apt-repos.md
